### PR TITLE
chores: Cleanup of legacy

### DIFF
--- a/lib/billymad/configuration.rb
+++ b/lib/billymad/configuration.rb
@@ -16,7 +16,7 @@ module Billymad
     end
 
     def api_url
-      _verify_configuration
+      verify_configuration
       @api_url ||= billomat_url
     end
 
@@ -25,12 +25,12 @@ module Billymad
     attr_reader :billomat_host
 
     def set_defaults
-      @api_format    = :json
+      @api_format = :json
       @billomat_host = BILLOMAT_HOST
     end
 
     def protocol
-      @protocol ||= @secure ? 'https' : 'http'
+      @protocol ||= secure ? 'https' : 'http'
     end
 
     def billomat_url
@@ -43,16 +43,16 @@ module Billymad
       logger
     end
 
-    def _verify_configuration
-      _verify_billomat_id
-      _verify_api_key
+    def verify_configuration
+      verify_billomat_id
+      verify_api_key
     end
 
-    def _verify_api_key
+    def verify_api_key
       raise Billymad::ConfigurationError, 'You must specify an API key' if api_key.nil?
     end
 
-    def _verify_billomat_id
+    def verify_billomat_id
       raise Billymad::ConfigurationError, 'You must specify an Billomat ID' if billomat_id.nil?
     end
   end

--- a/lib/billymad/resource/base.rb
+++ b/lib/billymad/resource/base.rb
@@ -5,6 +5,8 @@ module Billymad
       include Utils
       extend Validations
 
+      attr_reader :id, :created
+
       def initialize(attributes = {})
         set_attributes(attributes)
         convert_attributes
@@ -19,8 +21,8 @@ module Billymad
       end
 
       def convert_attributes
-        @id = id.to_i if @id
-        @created = Time.parse(created) if @created
+        @id = id.to_i if id
+        @created = Time.parse(created) if created
       end
 
       def prepare_results(response)

--- a/spec/billymad/configuration_spec.rb
+++ b/spec/billymad/configuration_spec.rb
@@ -16,7 +16,7 @@ describe Billymad::Configuration do
 
   describe '#api_url' do
     it 'is verifying configuration' do
-      expect(configuration).to receive(:_verify_configuration)
+      expect(configuration).to receive(:verify_configuration)
       configuration.api_url
     end
 


### PR DESCRIPTION
This PR:
- will make use of `getters` instead of accessing instance variables directly
- eliminate `_` prefixed method naming 